### PR TITLE
Update orgDBOrgSettings.html

### DIFF
--- a/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
+++ b/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
@@ -300,6 +300,9 @@
                 if (stringInput) {
                     return stringInput.toString().toLowerCase();
                 }
+                else if(nameOfStringVariable == "Xrm.Page.context.getOrgUniqueName()"){
+                    return "";                    
+                }
                 throw new Error("ERROR: getSafeLowerCaseString(): variable " + nameOfStringVariable + " is null!");
             },
             getSoapError: function (faultXml) {


### PR DESCRIPTION
This function was throwing an error that stopped the settings page from showing, Xrm.Page.context.getOrgUniqueName() is returning undefined for some reason, but as I analyzed the purpose of getOrgRootUrl(), I noticed that for most cases, the resulting string from getOrgRootUrl would be correct if this string is empty.