### PR TITLE
webapi version change and new setting

### DIFF
--- a/mspfedyn_/OrgDbOrgSettings/Settings.xml
+++ b/mspfedyn_/OrgDbOrgSettings/Settings.xml
@@ -1263,6 +1263,17 @@
     description="Default value is false, if it's set to True: do not show the following track options in Personal Options (Email): 'All email messages', 'Email messages from D365 Leads, Contacts and Accounts', 'Email messages from D365 records that are email enabled'"/>  
   
   <!--ORGANIZTION ATTRIBUTE Settings - these are NOT OrgDbOrgSettings but Organization.Attribute(s) -->
+  <orgSetting minSupportedVersion="9.1.0.1100"
+            maxSupportedVersion="9.9.9999.9999"
+            name="EnableUnifiedInterfaceShellRefresh"
+            isOrganizationAttribute="true"
+            min=""
+            max=""
+            defaultValue="false"
+            settingType="Boolean"
+            supportUrl="http://msdn.microsoft.com/en-us/library/gg328408.aspx"
+            urlTitle="Organization entity attributes"
+            description="As of 1/15/2019 the default is Disabled but the default may be True for newly provisioned instances.  Enabled/True or enables the new UCI Sitemap, if this is set to disabled the new UCI sitemap changes will be disabled." />
   <orgSetting minSupportedVersion="8.0.0.0"
             maxSupportedVersion="9.9.9999.9999"
             name="IsSOPIntegrationEnabled"
@@ -1273,7 +1284,7 @@
             settingType="Boolean"
             supportUrl="http://msdn.microsoft.com/en-us/library/gg328408.aspx"
             urlTitle="Organization entity attributes"
-            description="Enables or disables the SOPIntegration, if this is set to disabled it disables sales order processing assuming an integration will handle it.  *DO NOT DISABLE THIS UNLESS YOU HAVE A SPECIFIC REASON TO DO SO*" />
+            description="Enables or disables the SOPIntegration, if this is ENABLED it *disables* sales order processing assuming an integration will handle it.  *DO NOT SET TO TRUE UNLESS YOU HAVE A SPECIFIC REASON TO DO SO*" />
   <orgSetting minSupportedVersion="5.0.9690.583"
             maxSupportedVersion="9.9.9999.9999"
             name="MaxRecordsForExportToExcel"

--- a/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
+++ b/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
@@ -23,6 +23,26 @@
             SDK = { __namespace: true };
         };
         SDK.SOAP = {
+            getVersionSpecificWebApiUrl: function () {
+                var serverBuildVersion = new BuildVersion(8, 0, 0, 0);
+
+                //get the org version 
+                this.getCrmOrgDBVersion(
+                    onSuccess = function (serverVersion) {
+                        serverBuildVersion = serverVersion; 
+                    },
+                    onError = function (error) {});
+
+                if (serverBuildVersion.major >= 9 && serverBuildVersion.minor >= 1) {
+                    return "/api/data/v9.1";
+                }
+                if (serverBuildVersion.major == 9 && serverBuildVersion.minor == 0) {
+                    return "/api/data/v9.0";
+                }
+                else {
+                    return "/api/data/v8.0";
+                }
+            },
             getCrmOrgDBVersion: function (successCallback, errorCallback) {
                 ///<summary>Async retrieves the newest version from CRM's about.aspx page</summary>
                 ///<param name="successCallback" Type="Function(BuildVersion)">The function to perform when an successfult response is returned. 
@@ -105,7 +125,7 @@
                     type: "GET",
                     contentType: "application/json; charset=utf-8",
                     datatype: "json",
-                    url: rootUrl + "/api/data/v8.0/organizations",
+                    url: rootUrl + this.getVersionSpecificWebApiUrl() + "/organizations",
                     data: null,
                     beforeSend: function (XMLHttpRequest) {
                         //Specifying this header ensures that the results will be returned as JSON.
@@ -131,7 +151,7 @@
                     contentType: "application/json; charset=utf-8",
                     datatype: "json",
                     //method: "MERGE", //not working on some IE/JQUERY versions 
-                    url: rootUrl + "/api/data/v8.0/organizations" + "(" + organizationId + ")",
+                    url: rootUrl + this.getVersionSpecificWebApiUrl() + "/organizations" + "(" + organizationId + ")",
                     data: oJSON.stringify({ orgdborgsettings: orgDbOrgSettingXml }),
                     beforeSend: function (XMLHttpRequest) {
                         XMLHttpRequest.setRequestHeader("Accept", "application/json");
@@ -173,7 +193,7 @@
                     type: "PATCH",
                     contentType: "application/json; charset=utf-8",
                     datatype: "json",
-                    url: rootUrl + "/api/data/v8.0/organizations" + "(" + organizationId + ")",
+                    url: rootUrl + this.getVersionSpecificWebApiUrl() + "/organizations" + "(" + organizationId + ")",
                     data: oJSON.stringify(update),
                     beforeSend: function (XMLHttpRequest) {
                         XMLHttpRequest.setRequestHeader("Accept", "application/json");
@@ -203,7 +223,7 @@
                     type: "PATCH",
                     contentType: "application/json; charset=utf-8",
                     datatype: "json",
-                    url: rootUrl + "/api/data/v8.0/organizations" + "(" + organizationId + ")",
+                    url: rootUrl + this.getVersionSpecificWebApiUrl() + "/organizations" + "(" + organizationId + ")",
                     data: oJSON.stringify(update),
                     beforeSend: function (XMLHttpRequest) {
                         XMLHttpRequest.setRequestHeader("Accept", "application/json");
@@ -223,7 +243,7 @@
                     type: "GET",
                     contentType: "application/json; charset=utf-8",
                     datatype: "json",
-                    url: rootUrl + "/api/data/v8.0/solutions?$select=modifiedon,uniquename,organizationid,ismanaged,publisherid,version,versionnumber&$filter=uniquename eq 'OrganizationSettingsEditor'",
+                    url: rootUrl + this.getVersionSpecificWebApiUrl() +"/solutions?$select=modifiedon,uniquename,organizationid,ismanaged,publisherid,version,versionnumber&$filter=uniquename eq 'OrganizationSettingsEditor'",
                     data: null,
                     beforeSend: function (XMLHttpRequest) {
                         //Specifying this header ensures that the results will be returned as JSON.


### PR DESCRIPTION
Updated webapi calls to use a version specific webapi so that new setting values will function properly, 8.x will use v8.0, 9.0 will use v9.0, v9.1 or higher will use v9.1. 
+ EnableUnifiedInterfaceShellRefresh (Boolean organization attribute)