### PR TITLE
Fix error handling for non-Error objects in catch blocks

### DIFF
--- a/mspfedyn_/OrgDbOrgSettings/Solution/WebResources/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
+++ b/mspfedyn_/OrgDbOrgSettings/Solution/WebResources/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
@@ -726,6 +726,24 @@
             }
             return retval;
         };
+        function getErrorMessage(e) {
+            ///<summary>Safely extracts an error message from any error type</summary>
+            ///<param name='e' type='Object'>Error object of any type</param>
+            ///<returns type='String'>Error message string</returns>
+            if (e instanceof Error) return e.message || e.name || e.toString();
+            if (typeof e === 'string') return e;
+            if (e && typeof e === 'object') {
+                if (e.message) return e.message;
+                if (e.statusText) return e.statusText;
+                if (e.responseText) return e.responseText;
+                try {
+                    return JSON.stringify(e);
+                } catch (jsonError) {
+                    return Object.prototype.toString.call(e);
+                }
+            }
+            return e != null ? String(e) : 'Unknown error';
+        };
         function resetYammerAttributes() {
             try { //double confirmation for this setting, just in case. 
                 var result = confirm("Proceed with removing your Yammer configuration from CRM? This should only be done when advised to do so or when required to fall back to using Activity Feeds.");
@@ -746,7 +764,7 @@
                 }
             }
             catch (e) {
-                alert("Error editing setting in CRM - " + e.message);
+                alert("Error editing setting in CRM - " + getErrorMessage(e));
                 printSettingsToDiv();
                 enableProgressDiv(false);
             }
@@ -814,7 +832,7 @@
                 }
             }
             catch (e) {
-                alert("Error editing setting in CRM - " + e.message);
+                alert("Error editing setting in CRM - " + getErrorMessage(e));
                 printSettingsToDiv();
                 enableProgressDiv(false); 
             }

--- a/mspfedyn_/OrgDbOrgSettings/Solution/WebResources/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
+++ b/mspfedyn_/OrgDbOrgSettings/Solution/WebResources/mspfedyn_/OrgDbOrgSettings/orgDBOrgSettings.html
@@ -544,7 +544,16 @@
             this.value = value
             this.type = type;
             this.minNumber = parseFloat(min).toString() === "NaN" ? null : parseFloat(min);
-            this.maxNumber = parseFloat(max).toString() === "NaN" ? null : parseFloat(max);
+            
+            // Handle empty or null max values for Number/Double types
+            var parsedMax = parseFloat(max);
+            if (isNaN(parsedMax) || max === "" || max === null || max === undefined) {
+                // For Number/Double types, use Int32.MaxValue as default max
+                this.maxNumber = (type && (type.toString().toLowerCase() === "number" || type.toString().toLowerCase() === "double")) ? 2147483647 : null;
+            } else {
+                this.maxNumber = parsedMax;
+            }
+            
             this.defaultValue = defaultValue;
             this.supportUrl = supportUrl || "#";
             this.description = description;


### PR DESCRIPTION
* Add getErrorMessage helper and update error handling in catch blocks #155 
* Fix getErrorMessage to properly handle null/undefined values
* Add safety handling for JSON.stringify to prevent circular reference errors
* Add e.name fallback for Error objects to provide more meaningful messages
* Fix Number/Double validation for settings with empty max values (https://github.com/seanmcne/OrgDbOrgSettings/pull/157)
* Fix Number validation for settings with empty max values
* Add undefined check to maxNumber handling based on code review feedback